### PR TITLE
Don't use yarn --check-cache because it's slow.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,28 +161,29 @@ public/css:
 public/js/locales:
 	mkdir -p public/js/locales
 
-public/webfonts: | $(OBJDIRS)
+public/webfonts: | yarn.lock $(OBJDIRS)
 	cp -r node_modules/@fortawesome/fontawesome-free/webfonts public/webfonts
 
-public/dist/font: | $(OBJDIRS)
+public/dist/font: | yarn.lock $(OBJDIRS)
 	cp -r node_modules/summernote/dist/font public/dist/font
 
-public/js/locales/summernote: | $(OBJDIRS)
+public/js/locales/summernote: | yarn.lock $(OBJDIRS)
 	cp -r node_modules/summernote/dist/lang public/js/locales/summernote
 
-public/js/locales/bootstrap-select: | $(OBJDIRS)
+public/js/locales/bootstrap-select: | yarn.lock $(OBJDIRS)
 	cp -r node_modules/bootstrap-select/dist/js/i18n public/js/locales/bootstrap-select 
 
-public/js/locales/fullcalendar: | $(OBJDIRS)
+public/js/locales/fullcalendar: | yarn.lock $(OBJDIRS)
 	cp -r node_modules/fullcalendar/dist/locale public/js/locales/fullcalendar 
 
-public/js/locales/fullcalendar-core: | $(OBJDIRS)
+public/js/locales/fullcalendar-core: | yarn.lock $(OBJDIRS)
 	cp -r node_modules/@fullcalendar/core/locales public/js/locales/fullcalendar-core
 
-public/js/swagger-ui.js: node_modules/swagger-ui-dist/swagger-ui.js | $(OBJDIRS)
+public/js/swagger-ui.js: node_modules/swagger-ui-dist/swagger-ui.js | yarn.lock $(OBJDIRS)
 	cp -r node_modules/swagger-ui-dist/*.js node_modules/swagger-ui-dist/*.js.map public/js
 	cp -r node_modules/swagger-ui-dist/*.css node_modules/swagger-ui-dist/*.css.map public/css
 
+node_modules/swagger-ui-dist/swagger-ui.js: yarn.lock
 
 # This doesn't just generate en.json, but all locale files.
 # However, as they are updated all at the same time, en.json
@@ -199,8 +200,13 @@ run: build
 # This packs a release. Due to the way the data/ folder is structured,
 # we need to be careful to include only the files we need.
 .PHONY=release
-release: YARNFLAGS=--check-cache
-release: publish manifest
+release:
+	${MAKE} clean
+	${MAKE} pack
+
+.PHONY=pack
+pack: YARNFLAGS=--check-cache
+pack: publish manifest
 	mkdir -p release
 	tar cvfJ release/not-grocy-$(shell git describe --tags).tar.xz \
 		changelog \

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ publish: build minify
 # https://stackoverflow.com/a/44249374/10045846
 
 yarn.lock: node_modules package.json
-	${YARN} install --check-cache
+	${YARN} install ${YARNFLAGS}
 	@touch -mr $(shell ls -Atd $? | head -1) $@
 
 node_modules:
@@ -199,6 +199,7 @@ run: build
 # This packs a release. Due to the way the data/ folder is structured,
 # we need to be careful to include only the files we need.
 .PHONY=release
+release: YARNFLAGS=--check-cache
 release: publish manifest
 	mkdir -p release
 	tar cvfJ release/not-grocy-$(shell git describe --tags).tar.xz \

--- a/Makefile
+++ b/Makefile
@@ -205,7 +205,6 @@ release:
 	${MAKE} pack
 
 .PHONY=pack
-pack: YARNFLAGS=--check-cache
 pack: publish manifest
 	mkdir -p release
 	tar cvfJ release/not-grocy-$(shell git describe --tags).tar.xz \


### PR DESCRIPTION
It also doesn't seem to be that useful when developing locally.

https://yarnpkg.com/cli/install
> If the --check-cache option is set, Yarn will always refetch the packages and will ensure that their checksum matches what's 1/ described in the lockfile 2/ inside the existing cache files (if present). This is recommended as part of your CI workflow if you're both following the Zero-Installs model and accepting PRs from third-parties, as they'd otherwise have the ability to alter the checked-in packages before submitting them.